### PR TITLE
close BufferedReader in countLines

### DIFF
--- a/src/main/java/com/jdon/jivejdon/domain/model/message/output/codeviewer/JavaCodeHighlighter.java
+++ b/src/main/java/com/jdon/jivejdon/domain/model/message/output/codeviewer/JavaCodeHighlighter.java
@@ -790,15 +790,16 @@ public class JavaCodeHighlighter implements Function<MessageVO, MessageVO> {
 
 	private final int countLines(String text) {
 		int lineCount = 0;
-		BufferedReader reader = new BufferedReader(new StringReader(text));
-		try {
-			while (reader.readLine() != null) {
-				lineCount++;
+		try (BufferedReader reader = new BufferedReader(new StringReader(text))) {
+			try {
+				while (reader.readLine() != null) {
+					lineCount++;
+				}
+			} catch (IOException ioe) {
+				ioe.printStackTrace();
 			}
-		} catch (IOException ioe) {
-			ioe.printStackTrace();
+			return lineCount;
 		}
-		return lineCount;
 	}
 
 	private final String deleteCarriages(String line) {


### PR DESCRIPTION
countLines is close — The resource opened there can leak if countLines exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path. Happy to drop this if it doesn’t fit.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.